### PR TITLE
Add CreateDrawingForm component with borderless design

### DIFF
--- a/src/app/components/drawing/CreateDrawingForm.stories.tsx
+++ b/src/app/components/drawing/CreateDrawingForm.stories.tsx
@@ -1,0 +1,266 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CreateDrawingForm } from './CreateDrawingForm';
+import { LayoutContainer } from '@/app/components/layout/LayoutContainer';
+import { fn } from 'storybook/test';
+
+const meta: Meta<typeof CreateDrawingForm> = {
+  title: 'Components/Drawing/CreateDrawingForm',
+  component: CreateDrawingForm,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onSubmit: { action: 'submitted' },
+    onCancel: { action: 'cancelled' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CreateDrawingForm>;
+
+// Default form - empty state
+export const Default: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+  },
+};
+
+// With initial data
+export const WithInitialData: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+    initialData: {
+      title: 'System Architecture',
+      description: 'Diagram showing the microservices architecture for our platform',
+      isPublic: true,
+    },
+  },
+};
+
+// Loading state
+export const Loading: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+    loading: true,
+    initialData: {
+      title: 'New Drawing',
+      description: 'Creating...',
+      isPublic: false,
+    },
+  },
+};
+
+// Public drawing (switch enabled)
+export const PublicDrawing: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+    initialData: {
+      title: 'Team Brainstorm',
+      isPublic: true,
+    },
+  },
+};
+
+// Private drawing (switch disabled)
+export const PrivateDrawing: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+    initialData: {
+      title: 'Personal Notes',
+      description: 'Private sketches and ideas',
+      isPublic: false,
+    },
+  },
+};
+
+// Centered layout (recommended for create page)
+export const CenteredLayout: Story = {
+  render: (args: typeof meta.args) => (
+    <LayoutContainer variant="centered">
+      <CreateDrawingForm {...args} />
+    </LayoutContainer>
+  ),
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+// Compact layout (for modals)
+export const CompactLayout: Story = {
+  render: (args: typeof meta.args) => (
+    <LayoutContainer variant="compact">
+      <CreateDrawingForm {...args} />
+    </LayoutContainer>
+  ),
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+// Mobile view
+export const MobileView: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};
+
+// Tablet view
+export const TabletView: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet',
+    },
+  },
+};
+
+// Form validation demo (empty title)
+export const ValidationError: Story = {
+  render: () => {
+    const handleSubmit = async () => {
+      // This will trigger validation error since title is empty
+      return Promise.resolve();
+    };
+
+    return (
+      <div className="space-y-4">
+        <div className="bg-muted p-4 rounded-lg">
+          <p className="text-sm font-medium mb-2">Try submitting without a title</p>
+          <p className="text-xs text-muted-foreground">
+            The form validates that a title is required. Click "Create Drawing" to see the validation error.
+          </p>
+        </div>
+        <CreateDrawingForm onSubmit={handleSubmit} onCancel={fn()} />
+      </div>
+    );
+  },
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+// Interactive demo with all states
+export const InteractiveStates: Story = {
+  render: () => (
+    <div className="space-y-8 p-8 bg-muted/20 min-h-screen">
+      <div>
+        <h2 className="text-2xl font-bold mb-4">Create Drawing Form States</h2>
+        <p className="text-muted-foreground mb-4">
+          Form component for creating new Excalidraw drawings with validation and privacy controls.
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <div>
+          <h3 className="text-lg font-semibold mb-3">Empty Form</h3>
+          <p className="text-sm text-muted-foreground mb-4">
+            Default state with no initial data
+          </p>
+          <div className="max-w-2xl">
+            <CreateDrawingForm onSubmit={fn()} onCancel={fn()} />
+          </div>
+        </div>
+
+        <div className="border-t pt-8">
+          <h3 className="text-lg font-semibold mb-3">Pre-filled Data</h3>
+          <p className="text-sm text-muted-foreground mb-4">
+            Form with initial values (edit mode simulation)
+          </p>
+          <div className="max-w-2xl">
+            <CreateDrawingForm
+              onSubmit={fn()}
+              onCancel={fn()}
+              initialData={{
+                title: 'Wireframe Design',
+                description: 'Mobile app wireframe with key user flows',
+                isPublic: true,
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="border-t pt-8">
+          <h3 className="text-lg font-semibold mb-3">Loading State</h3>
+          <p className="text-sm text-muted-foreground mb-4">
+            Form disabled while submitting
+          </p>
+          <div className="max-w-2xl">
+            <CreateDrawingForm
+              onSubmit={fn()}
+              onCancel={fn()}
+              loading={true}
+              initialData={{
+                title: 'New Drawing',
+                isPublic: false,
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+// Recommended layout for create page
+export const RecommendedCreatePage: Story = {
+  render: () => (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+      <LayoutContainer variant="centered">
+        <div className="space-y-4">
+          <div className="text-center mb-6">
+            <h1 className="text-3xl font-bold mb-2">Start Creating</h1>
+            <p className="text-muted-foreground">
+              Set up your new drawing and start diagramming
+            </p>
+          </div>
+          <CreateDrawingForm
+            onSubmit={fn()}
+            onCancel={fn()}
+          />
+        </div>
+      </LayoutContainer>
+    </div>
+  ),
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+// Dark mode demo
+export const DarkMode: Story = {
+  args: {
+    onSubmit: fn(),
+    onCancel: fn(),
+  },
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+};

--- a/src/app/components/drawing/CreateDrawingForm.tsx
+++ b/src/app/components/drawing/CreateDrawingForm.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/app/components/ui/Card"
+import { Input } from "@/app/components/ui/Input"
+import { Label } from "@/app/components/ui/Label"
+import { Textarea } from "@/app/components/ui/textarea"
+import { Switch } from "@/app/components/ui/switch"
+import { Button } from "@/app/components/ui/Button"
+import type { CreateDrawingFormProps, CreateDrawingFormData } from "@/types/drawing"
+
+export const CreateDrawingForm = React.forwardRef<HTMLDivElement, CreateDrawingFormProps>(
+  ({ onSubmit, onCancel, initialData, loading = false, className }, ref) => {
+    const [formData, setFormData] = React.useState<CreateDrawingFormData>({
+      title: initialData?.title || "",
+      description: initialData?.description || "",
+      isPublic: initialData?.isPublic ?? false,
+    })
+
+    const [errors, setErrors] = React.useState<Partial<Record<keyof CreateDrawingFormData, string>>>({})
+
+    const handleSubmit = async (e: React.FormEvent) => {
+      e.preventDefault()
+
+      // Simple validation
+      const newErrors: Partial<Record<keyof CreateDrawingFormData, string>> = {}
+
+      if (!formData.title.trim()) {
+        newErrors.title = "Title is required"
+      }
+
+      if (Object.keys(newErrors).length > 0) {
+        setErrors(newErrors)
+        return
+      }
+
+      setErrors({})
+      await onSubmit?.(formData)
+    }
+
+    const handleCancel = () => {
+      setFormData({
+        title: "",
+        description: "",
+        isPublic: false,
+      })
+      setErrors({})
+      onCancel?.()
+    }
+
+    return (
+      <Card ref={ref} className={cn("w-full border-0 shadow-none", className)}>
+        <form onSubmit={handleSubmit}>
+          <CardHeader>
+            <CardTitle>Create New Drawing</CardTitle>
+            <CardDescription>
+              Start a new Excalidraw diagram. Add a title and description to help you find it later.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="space-y-6">
+            {/* Title Input */}
+            <div className="space-y-2">
+              <Label htmlFor="title">
+                Title <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="title"
+                placeholder="Enter drawing title"
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                disabled={loading}
+                aria-invalid={!!errors.title}
+                aria-describedby={errors.title ? "title-error" : undefined}
+              />
+              {errors.title && (
+                <p id="title-error" className="text-sm text-destructive">
+                  {errors.title}
+                </p>
+              )}
+            </div>
+
+            {/* Description Textarea */}
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                placeholder="Add a description (optional)"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                disabled={loading}
+                rows={4}
+              />
+              <p className="text-xs text-muted-foreground">
+                Help others understand what this drawing is about
+              </p>
+            </div>
+
+            {/* Privacy Toggle */}
+            <div className="flex items-center justify-between space-x-2 pt-2 mt-2">
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="isPublic" className="cursor-pointer">
+                  Make this drawing public
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  {formData.isPublic
+                    ? "Anyone with the link can view this drawing"
+                    : "Only you can view this drawing"}
+                </p>
+              </div>
+              <Switch
+                id="isPublic"
+                checked={formData.isPublic}
+                onCheckedChange={(checked) => setFormData({ ...formData, isPublic: checked })}
+                disabled={loading}
+              />
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex justify-between gap-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={loading}
+              className="flex-1 sm:flex-none"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="flex-1 sm:flex-none"
+            >
+              {loading ? "Creating..." : "Create Drawing"}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    )
+  }
+)
+
+CreateDrawingForm.displayName = "CreateDrawingForm"

--- a/src/app/components/layout/LayoutContainer.stories.tsx
+++ b/src/app/components/layout/LayoutContainer.stories.tsx
@@ -1,0 +1,177 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LayoutContainer } from './LayoutContainer';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/Card';
+
+const meta: Meta<typeof LayoutContainer> = {
+  title: 'Components/Layout/LayoutContainer',
+  component: LayoutContainer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['centered', 'full', 'compact', 'narrow'],
+      description: 'Layout variant',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LayoutContainer>;
+
+// Sample content for demonstrations
+const SampleCard = () => (
+  <Card>
+    <CardHeader>
+      <CardTitle>Sample Content</CardTitle>
+      <CardDescription>This demonstrates the layout container behavior</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <p className="text-sm text-muted-foreground">
+        The layout container controls how content is positioned on the page.
+        Try different variants to see how the content adapts.
+      </p>
+    </CardContent>
+  </Card>
+);
+
+// Centered variant (default) - good for forms and focused content
+export const Centered: Story = {
+  args: {
+    variant: 'centered',
+    children: <SampleCard />,
+  },
+};
+
+// Full width variant - good for dashboards and list views
+export const Full: Story = {
+  args: {
+    variant: 'full',
+    children: (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-bold">Dashboard</h1>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <SampleCard />
+          <SampleCard />
+          <SampleCard />
+        </div>
+      </div>
+    ),
+  },
+};
+
+// Compact variant - good for modals and small forms
+export const Compact: Story = {
+  args: {
+    variant: 'compact',
+    children: <SampleCard />,
+  },
+};
+
+// Narrow variant - good for reading content
+export const Narrow: Story = {
+  args: {
+    variant: 'narrow',
+    children: (
+      <Card>
+        <CardHeader>
+          <CardTitle>Article Title</CardTitle>
+          <CardDescription>A narrower layout for better readability</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+            quis nostrud exercitation ullamco laboris.
+          </p>
+          <p className="text-sm">
+            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+            eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.
+          </p>
+        </CardContent>
+      </Card>
+    ),
+  },
+};
+
+// Comparison of all variants
+export const AllVariants: Story = {
+  render: () => (
+    <div className="space-y-8 bg-muted/20">
+      <div>
+        <h2 className="text-2xl font-bold mb-4 px-4 pt-4">Layout Container Variants</h2>
+        <p className="text-muted-foreground mb-4 px-4">
+          Different layout options for different use cases
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <div className="border-t pt-8">
+          <h3 className="text-lg font-semibold mb-2 px-4">Centered (max-w-2xl)</h3>
+          <p className="text-sm text-muted-foreground mb-4 px-4">
+            Perfect for forms and focused content. Vertically and horizontally centered.
+          </p>
+          <div className="bg-blue-50 dark:bg-blue-950 min-h-[300px]">
+            <LayoutContainer variant="centered">
+              <SampleCard />
+            </LayoutContainer>
+          </div>
+        </div>
+
+        <div className="border-t pt-8">
+          <h3 className="text-lg font-semibold mb-2 px-4">Full (container)</h3>
+          <p className="text-sm text-muted-foreground mb-4 px-4">
+            Uses full width with responsive container padding. Good for dashboards.
+          </p>
+          <div className="bg-green-50 dark:bg-green-950 min-h-[300px]">
+            <LayoutContainer variant="full">
+              <SampleCard />
+            </LayoutContainer>
+          </div>
+        </div>
+
+        <div className="border-t pt-8">
+          <h3 className="text-lg font-semibold mb-2 px-4">Compact (max-w-md)</h3>
+          <p className="text-sm text-muted-foreground mb-4 px-4">
+            Smaller centered layout. Great for login forms and modals.
+          </p>
+          <div className="bg-purple-50 dark:bg-purple-950 min-h-[300px]">
+            <LayoutContainer variant="compact">
+              <SampleCard />
+            </LayoutContainer>
+          </div>
+        </div>
+
+        <div className="border-t pt-8">
+          <h3 className="text-lg font-semibold mb-2 px-4">Narrow (max-w-lg)</h3>
+          <p className="text-sm text-muted-foreground mb-4 px-4">
+            Optimized for reading. Good for articles and content pages.
+          </p>
+          <div className="bg-orange-50 dark:bg-orange-950 min-h-[300px]">
+            <LayoutContainer variant="narrow">
+              <SampleCard />
+            </LayoutContainer>
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+// Mobile responsive demo
+export const MobileResponsive: Story = {
+  args: {
+    variant: 'centered',
+    children: <SampleCard />,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};

--- a/src/app/components/layout/LayoutContainer.tsx
+++ b/src/app/components/layout/LayoutContainer.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface LayoutContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'centered' | 'full' | 'compact' | 'narrow'
+  children: React.ReactNode
+}
+
+const LayoutContainer = React.forwardRef<HTMLDivElement, LayoutContainerProps>(
+  ({ variant = 'centered', className, children, ...props }, ref) => {
+    const isCentered = variant === 'centered' || variant === 'compact' || variant === 'narrow'
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "w-full",
+          isCentered ? "min-h-screen flex items-center justify-center p-4" : "container mx-auto px-4 py-8",
+          className
+        )}
+        {...props}
+      >
+        <div
+          className={cn({
+            "w-full max-w-2xl": variant === 'centered',
+            "w-full": variant === 'full',
+            "w-full max-w-md": variant === 'compact',
+            "w-full max-w-lg": variant === 'narrow',
+          })}
+        >
+          {children}
+        </div>
+      </div>
+    )
+  }
+)
+
+LayoutContainer.displayName = "LayoutContainer"
+
+export { LayoutContainer }

--- a/src/app/components/ui/switch.tsx
+++ b/src/app/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface SwitchProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  checked?: boolean
+  onCheckedChange?: (checked: boolean) => void
+}
+
+const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
+  ({ className, checked, onCheckedChange, onChange, ...props }, ref) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(e)
+      onCheckedChange?.(e.target.checked)
+    }
+
+    return (
+      <label className={cn("relative inline-flex items-center cursor-pointer", className)}>
+        <input
+          type="checkbox"
+          className="sr-only peer"
+          ref={ref}
+          checked={checked}
+          onChange={handleChange}
+          {...props}
+        />
+        <div className="w-11 h-6 bg-muted rounded-full peer peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-background peer-checked:bg-primary peer-disabled:cursor-not-allowed peer-disabled:opacity-50 transition-colors">
+          <div className="absolute top-0.5 left-0.5 bg-background rounded-full h-5 w-5 transition-transform peer-checked:translate-x-5 shadow-sm"></div>
+        </div>
+      </label>
+    )
+  }
+)
+Switch.displayName = "Switch"
+
+export { Switch }

--- a/src/app/components/ui/textarea.tsx
+++ b/src/app/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/types/drawing.ts
+++ b/src/types/drawing.ts
@@ -21,3 +21,17 @@ export interface DrawingCardProps {
   showLastOpened?: boolean
   loading?: boolean
 }
+
+export interface CreateDrawingFormData {
+  title: string
+  description?: string
+  isPublic: boolean
+}
+
+export interface CreateDrawingFormProps {
+  onSubmit?: (data: CreateDrawingFormData) => void | Promise<void>
+  onCancel?: () => void
+  initialData?: Partial<CreateDrawingFormData>
+  loading?: boolean
+  className?: string
+}


### PR DESCRIPTION
## Summary
- Add CreateDrawingForm component for creating new drawings
- Add LayoutContainer component with layout variants (centered/full/compact/narrow)
- Add Textarea and Switch UI components
- Comprehensive Storybook stories for all components

## Design
- Borderless, minimal design using spacing for visual hierarchy
- Clean form with generous spacing (space-y-6)
- No borders on Card or internal sections
- Privacy toggle with Switch component
- Form validation for required fields

## Components Added
- **CreateDrawingForm**: Client component with title, description, and privacy controls
- **LayoutContainer**: Reusable layout wrapper with 4 variants
- **Textarea**: shadcn-style textarea component
- **Switch**: Custom toggle switch component

## Storybook Coverage
- 12+ CreateDrawingForm stories (layouts, validation, responsive)
- Layout comparison stories for LayoutContainer
- All stories demonstrate centered layout for create page

🤖 Generated with [Claude Code](https://claude.com/claude-code)